### PR TITLE
add Rudnick2018 citation for "RMS size of 1.5° remains"

### DIFF
--- a/depthaveragecurrents.bib
+++ b/depthaveragecurrents.bib
@@ -1,13 +1,15 @@
-@article{NicholsonFeen2017,
-author = {Nicholson, David P. and Feen, Melanie L.},
-title = {Air calibration of an oxygen optode on an underwater glider},
-journal = {Limnology and Oceanography: Methods},
-volume = {15},
-number = {5},
-pages = {495-502},
-doi = {https://doi.org/10.1002/lom3.10177},
-url = {https://aslopubs.onlinelibrary.wiley.com/doi/abs/10.1002/lom3.10177},
-eprint = {https://aslopubs.onlinelibrary.wiley.com/doi/pdf/10.1002/lom3.10177},
-abstract = {Abstract An Aanderaa Data Instruments 4831 oxygen optode was configured on an underwater glider such that the optode extended into the atmosphere during each glider surface interval enabling in situ calibration of the sensor by directly measuring the known oxygen partial pressure of the atmosphere. The approach, which has previously been implemented on profiling floats but not on gliders, was tested during a 15-d deployment at the New England shelf break in June 2016, a productive period during which surface O2 saturation averaged 110\%. Results were validated by shipboard Winkler O2 calibration casts, which were used to determine a sensor gain factor of 1.055 ± 0.004. Consistent with profiling float observations, air measurements contain contamination from splashing water and/or residual seawater on the sensor face. Glider surface measurements were determined to be a linear combination of 36\% of surface water and 64\% atmospheric air. When correcting air measurements for this effect, a sensor gain correction of 1.055 ± 0.005 was calculated based on comparing glider air measurements to the expected atmospheric pO2 calculated from atmospheric pressure and humidity data from a nearby NOAA buoy. Thus, the two approaches were in agreement and were both demonstrated to be accurate to within ±0.5\%. We expect uncertainty in the air-calibration could be further reduced by increasing the vertical positioning of the optode, lengthening deployment time, or operating in waters with surface O2 saturation closer to equilibrium.},
-year = {2017}
+@article {Rudnick2018,
+      author = "Daniel L. Rudnick and Jeffrey T. Sherman and Alexander P. Wu",
+      title = "Depth-Average Velocity from Spray Underwater Gliders",
+      journal = "Journal of Atmospheric and Oceanic Technology",
+      year = "2018",
+      publisher = "American Meteorological Society",
+      address = "Boston MA, USA",
+      volume = "35",
+      number = "8",
+      doi = "10.1175/JTECH-D-17-0200.1",
+      pages=      "1665 - 1673",
+      url = "https://journals.ametsoc.org/view/journals/atot/35/8/jtech-d-17-0200.1.xml"
 }
+
+


### PR DESCRIPTION
This PR will close #61 by adding Rudnick et al. 2018 as citation.