### PR TITLE
move references from introduction

### DIFF
--- a/sections/DACs_references.md
+++ b/sections/DACs_references.md
@@ -3,17 +3,19 @@
 ```{bibliography}
 ```
 
-|  Paper  |  Platform  |  Link |
-|---|---|---|
-| Bennett, J., Stahr, F., & Eriksen, C. (2019). Determining Seaglider Velocities Automatically. | Seaglider (flight) | http://hdl.handle.net/1773/44948 |
-| Bennett, J. S., Stahr, F. R., Eriksen, C. C., Renken, M. C., Snyder, W. E., & Van Uffelen, L. J. (2021). Assessing Seaglider Model-Based Position Accuracy on an Acoustic Tracking Range. Journal of Atmospheric and Oceanic Technology, 38(6), 1111-1123. | Seaglider (flight) | https://doi.org/10.1175/JTECH-D-20-0091.1 |
-| Davis, R. E., Kessler, W. S., & Sherman, J. T. (2012). Gliders measure western boundary current transport from the South Pacific to the equator. Journal of Physical Oceanography, 42(11), 2001-2013. | Spray (flight) | https://doi.org/10.1175/JPO-D-12-022.1 |
-| Eriksen, C. C., Osse, T. J., Light, R. D., Wen, T., Lehman, T. W., Sabin, P. L., ... & Chiodi, A. M. (2001). Seaglider: A long-range autonomous underwater vehicle for oceanographic research. IEEE Journal of oceanic Engineering, 26(4), 424-436. | Seaglider (flight) | https://doi.org/10.1109/48.972073 |
-| Frajka-Williams, E., Eriksen, C. C., Rhines, P. B., & Harcourt, R. R. (2011). Determining vertical water velocities from Seaglider. Journal of Atmospheric and Oceanic Technology, 28(12), 1641-1656. | Seaglider (flight) | https://doi.org/10.1175/2011JTECHO830.1 |
-| Merckelbach, L. M., Briggs, R. D., Smeed, D. A., & Griffiths, G. (2008, March). Current measurements from autonomous underwater gliders. In 2008 ieee/oes 9th working conference on current measurement technology (pp. 61-67). IEEE. | Slocum (flight) | https://doi.org/10.1109/CCM.2008.4480845 |
-| Merckelbach, L., Smeed, D., & Griffiths, G. (2010). Vertical water velocities from underwater gliders. Journal of Atmospheric and Oceanic Technology, 27(3), 547-563. | Sloum (flight) | https://doi.org/10.1175/2009JTECHO710.1 
-| Merckelbach, L., Berger, A., Krahmann, G., Dengler, M., & Carpenter, J. R. (2019). A dynamic flight model for Slocum gliders and implications for turbulence microstructure measurements. Journal of Atmospheric and Oceanic Technology, 36(2), 281-296. | Slocum (flight) | https://doi.org/10.1175/JTECH-D-18-0168.1 |
-| Merckelbach, L. M., & Carpenter, J. R. (2021). Ocean glider flight in the presence of surface waves. Journal of Atmospheric and Oceanic Technology. | Slocum (flight) | https://doi.org/10.1175/JTECH-D-20-0206.1 |
-| Rudnick, D. L., Sherman, J. T., & Wu, A. P. (2018). Depth-average velocity from Spray underwater gliders. Journal of Atmospheric and Oceanic Technology, 35(8), 1665-1673. | Spray (flight) | https://doi.org/10.1175/JTECH-D-17-0200.1 |
-| Sherman, J., Davis, R. E., Owens, W. B., & Valdes, J. (2001). The autonomous underwater glider" Spray". IEEE Journal of Oceanic Engineering, 26(4), 437-446. | Spray (flight) | https://doi.org/10.1109/48.972076 |
-| Todd, R. E., Rudnick, D. L., Sherman, J. T., Owens, W. B., & George, L. (2017). Absolute velocity estimates from autonomous underwater gliders equipped with Doppler current profilers. Journal of Atmospheric and Oceanic Technology, 34(2), 309-333. | Spray (comparison of DAC and ADCP) | https://doi.org/10.1175/JTECH-D-16-0156.1 |
+## Key references by platform
+
+|  Paper  |  Platform  |
+|---|---|
+| {cite}`bennett2019determining` | Seaglider (flight) |
+| {cite}`bennett2021assessing` | Seaglider (flight) |
+| {cite}`davis2012gliders` | Spray (flight) |
+| {cite}`eriksen2001seaglider` | Seaglider (flight) |
+| {cite}`frajka2011determining` | Seaglider (flight) |
+| {cite}`merckelbach2008current` | Slocum (flight) |
+| {cite}`merckelbach2010vertical` | Slocum (flight) |
+| {cite}`merckelbach2019dynamic` | Slocum (flight) |
+| {cite}`merckelbach2021ocean` | Slocum (flight) |
+| {cite}`rudnick2018depth` | Spray (flight) |
+| {cite}`sherman2001autonomous` | Spray (flight) |
+| {cite}`todd2017absolute` | Spray (comparison of DAC and ADCP) |

--- a/sections/DACs_references.md
+++ b/sections/DACs_references.md
@@ -2,3 +2,18 @@
 
 ```{bibliography}
 ```
+
+|  Paper  |  Platform  |  Link |
+|---|---|---|
+| Bennett, J., Stahr, F., & Eriksen, C. (2019). Determining Seaglider Velocities Automatically. | Seaglider (flight) | http://hdl.handle.net/1773/44948 |
+| Bennett, J. S., Stahr, F. R., Eriksen, C. C., Renken, M. C., Snyder, W. E., & Van Uffelen, L. J. (2021). Assessing Seaglider Model-Based Position Accuracy on an Acoustic Tracking Range. Journal of Atmospheric and Oceanic Technology, 38(6), 1111-1123. | Seaglider (flight) | https://doi.org/10.1175/JTECH-D-20-0091.1 |
+| Davis, R. E., Kessler, W. S., & Sherman, J. T. (2012). Gliders measure western boundary current transport from the South Pacific to the equator. Journal of Physical Oceanography, 42(11), 2001-2013. | Spray (flight) | https://doi.org/10.1175/JPO-D-12-022.1 |
+| Eriksen, C. C., Osse, T. J., Light, R. D., Wen, T., Lehman, T. W., Sabin, P. L., ... & Chiodi, A. M. (2001). Seaglider: A long-range autonomous underwater vehicle for oceanographic research. IEEE Journal of oceanic Engineering, 26(4), 424-436. | Seaglider (flight) | https://doi.org/10.1109/48.972073 |
+| Frajka-Williams, E., Eriksen, C. C., Rhines, P. B., & Harcourt, R. R. (2011). Determining vertical water velocities from Seaglider. Journal of Atmospheric and Oceanic Technology, 28(12), 1641-1656. | Seaglider (flight) | https://doi.org/10.1175/2011JTECHO830.1 |
+| Merckelbach, L. M., Briggs, R. D., Smeed, D. A., & Griffiths, G. (2008, March). Current measurements from autonomous underwater gliders. In 2008 ieee/oes 9th working conference on current measurement technology (pp. 61-67). IEEE. | Slocum (flight) | https://doi.org/10.1109/CCM.2008.4480845 |
+| Merckelbach, L., Smeed, D., & Griffiths, G. (2010). Vertical water velocities from underwater gliders. Journal of Atmospheric and Oceanic Technology, 27(3), 547-563. | Sloum (flight) | https://doi.org/10.1175/2009JTECHO710.1 
+| Merckelbach, L., Berger, A., Krahmann, G., Dengler, M., & Carpenter, J. R. (2019). A dynamic flight model for Slocum gliders and implications for turbulence microstructure measurements. Journal of Atmospheric and Oceanic Technology, 36(2), 281-296. | Slocum (flight) | https://doi.org/10.1175/JTECH-D-18-0168.1 |
+| Merckelbach, L. M., & Carpenter, J. R. (2021). Ocean glider flight in the presence of surface waves. Journal of Atmospheric and Oceanic Technology. | Slocum (flight) | https://doi.org/10.1175/JTECH-D-20-0206.1 |
+| Rudnick, D. L., Sherman, J. T., & Wu, A. P. (2018). Depth-average velocity from Spray underwater gliders. Journal of Atmospheric and Oceanic Technology, 35(8), 1665-1673. | Spray (flight) | https://doi.org/10.1175/JTECH-D-17-0200.1 |
+| Sherman, J., Davis, R. E., Owens, W. B., & Valdes, J. (2001). The autonomous underwater glider" Spray". IEEE Journal of Oceanic Engineering, 26(4), 437-446. | Spray (flight) | https://doi.org/10.1109/48.972076 |
+| Todd, R. E., Rudnick, D. L., Sherman, J. T., Owens, W. B., & George, L. (2017). Absolute velocity estimates from autonomous underwater gliders equipped with Doppler current profilers. Journal of Atmospheric and Oceanic Technology, 34(2), 309-333. | Spray (comparison of DAC and ADCP) | https://doi.org/10.1175/JTECH-D-16-0156.1 |


### PR DESCRIPTION
when moving ref from introduction, I forgot to copy them to the relevant section. This is fixed here + sorted in alphabetical order