### PR TITLE
set jupyter-book==0.12.3 for utterance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jupyter-book
+jupyter-book==0.12.3
 pyppeteer


### PR DESCRIPTION
@callumrollo or @isgiddy do you have capacity for a quick review? 

Was setting jupyter-book==0.12.3 the only action needed to make utterance work again? 
Just realised that this has not been done for this SOP so far. 

Follow this PR:
https://github.com/OceanGlidersCommunity/Salinity_SOP/pull/139/files

I leave the citation style improvement through pybtex-apa-style for future PRs for now.

FYI: @schultzl this might interest you in case you want to enable comments below your books.