### PR TITLE
link: OceanGliders 1.0 repo

### DIFF
--- a/sections/DACs_rtqc.md
+++ b/sections/DACs_rtqc.md
@@ -133,6 +133,6 @@ equal to (1-*t<sub>c</sub>*/`u_coast_time`) for
 
 ## Required Metadata and Real Time Data Processing
 
-Please read the requirments relevant for the [OceanGliders Format 1.0](https://github.com/OceanGlidersCommunity/OG-format-user-manual) before deploying your glider.
+Please read the requirements relevant for the [OceanGliders Format 1.0](https://github.com/OceanGlidersCommunity/OG-format-user-manual) before deploying your glider.
 
 - Set Angle of Attack parameters for slocum? 

--- a/sections/DACs_rtqc.md
+++ b/sections/DACs_rtqc.md
@@ -133,6 +133,6 @@ equal to (1-*t<sub>c</sub>*/`u_coast_time`) for
 
 ## Required Metadata and Real Time Data Processing
 
-Please read the requirements relevant for the [OceanGliders Format 1.0](https://github.com/OceanGlidersCommunity/OG-format-user-manual) before deploying your glider.
+Please read the metadata requirements relevant for the [OceanGliders Format](https://github.com/OceanGlidersCommunity/OG-format-user-manual) before deploying your glider.
 
 - Set Angle of Attack parameters for slocum? 

--- a/sections/DACs_rtqc.md
+++ b/sections/DACs_rtqc.md
@@ -133,5 +133,6 @@ equal to (1-*t<sub>c</sub>*/`u_coast_time`) for
 
 ## Required Metadata and Real Time Data Processing
 
-- link to OceanGliders Format 1.0 requirements
+Please read the requirments relevant for the [OceanGliders Format 1.0](https://github.com/OceanGlidersCommunity/OG-format-user-manual) before deploying your glider.
+
 - Set Angle of Attack parameters for slocum? 


### PR DESCRIPTION
I suggest to link the OG1.0 repo here. 

@callumrollo @vturpin maybe something you can try to do in all SOPs? It will help both SOPs and the adoption of OG1.0

I suggest to link to the repo as this name will likely not change compared to deployment links.  What do you think Callum?